### PR TITLE
Improve error reporting when config files are missing or invalid

### DIFF
--- a/src/Drupal/ContentTypeRegistry/ContentTypeRegistryYamlStorage.php
+++ b/src/Drupal/ContentTypeRegistry/ContentTypeRegistryYamlStorage.php
@@ -100,6 +100,8 @@ class ContentTypeRegistryYamlStorage implements ContentTypeRegistryStorageInterf
         } elseif (file_exists($globalConfigFile)) {
             $yaml = file_get_contents($globalConfigFile);
             $this->config = Yaml::parse($yaml);
+        } else {
+            throw new ConfigurationException("Content Type Registry: no configuration files found.");
         }
     }
 
@@ -116,7 +118,7 @@ class ContentTypeRegistryYamlStorage implements ContentTypeRegistryStorageInterf
         $globalFields = array();
 
         if (empty($this->config)) {
-            throw new ConfigurationException("Configuration file is invalid");
+            throw new ConfigurationException("Content Type Registry: configuration file is invalid.");
         }
 
         if (isset($this->config['GlobalFields'])) {


### PR DESCRIPTION
1. Add Content Type Registry to composer.son and install
2. Add DrupalContentTypeRegistry to the *.suite.yml file
3. Do NOT add the contentTypes.yml file
4. Run suite

Result is a not very helpful exception/error message:

`[Codeception\Exception\Configuration] Configuration file is invalid`

This minor PR improves this message and prefixes others with "Content Type Registry" so we clearly know where the message stems from, i.e.
- `[Codeception\Exception\Configuration] Content Type Registry: no configuration files found.`
- `[Codeception\Exception\Configuration] Content Type Registry: configuration file is invalid.`
