### PR TITLE
Improve exception message for missing selector

### DIFF
--- a/src/Drupal/ContentTypeRegistry/Widgets/MediaBrowserWidget.php
+++ b/src/Drupal/ContentTypeRegistry/Widgets/MediaBrowserWidget.php
@@ -45,7 +45,7 @@ class MediaBrowserWidget extends MediaWidget
 
         if (!preg_match('/^#edit\-([\w\-]+)\-upload$/', $selector, $matches)) {
             throw new \InvalidArgumentException(
-                "Must specify the input field, beginning with edit- and ending in -upload"
+                "Must specify the input field, beginning with '#edit-' and ending in '-upload'."
             );
         }
 


### PR DESCRIPTION
The original message was unclear/incorrect, stating the selector value must begin with 'edit-', whereas I have found the selector needs to include the hash symbol.
